### PR TITLE
CLI - Print warning when diff is found instead of opening program

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,10 +7,25 @@ var fs = require("fs")
 var serverPath = path.join(__dirname, "./server.js")
 var args = [serverPath];
 
-if (!process.stdin.isTTY) {
-  var proc = spawn(electron, args)
-  process.stdin.pipe(proc.stdin)
-} else {
-  console.error("No stdin provided");
-  process.exit(1);
-}
+var hasRead = false;
+process.stdin.on('readable', function () {
+  var partial = process.stdin.read(1);
+  if (!partial) {
+    console.error("Your branch has no changes to view.");
+    process.exit(0);
+  }
+  if (partial && !hasRead) {
+    partial = partial.toString().trim();
+    hasRead = true;
+    if (!process.stdin.isTTY && partial !== "") {
+      var proc = spawn(electron, args)
+      process.stdin.pipe(proc.stdin)
+    } else if (partial === "") {
+      console.error("Your branch has no changes to view.");
+      process.exit(0);
+    } else {
+      console.error("No stdin provided");
+      process.exit(1);
+    }
+  }
+});


### PR DESCRIPTION
Instead of opening the program when there is no diff, it simply writes to the console that there are no changes. This saves time because Electron does take a second to open up and display warning that the diff cannot be parsed.

Essentially, it just checks the first byte to make sure it has an actual value. We may want to allow empty string as a valid case but I did include it in this pull request.
